### PR TITLE
when resolving "localhost", try absolute value first

### DIFF
--- a/src/addressresolver.cpp
+++ b/src/addressresolver.cpp
@@ -56,7 +56,7 @@ public:
 			return;
 		}
 
-		if(host.contains("."))
+		if(host.contains(".") || host == "localhost")
 			absoluteFirst = true;
 
 		nextQuery();


### PR DESCRIPTION
Trying to append search domains to "localhost" isn't useful,
and may significantly slow down name resolution if done first.