### PR TITLE
Fix build with OpenSSL 1.1

### DIFF
--- a/src/httprequest_curl.cpp
+++ b/src/httprequest_curl.cpp
@@ -563,7 +563,11 @@ public:
 
 	int sslVerifyCallback(X509_STORE_CTX *x509StoreContext)
 	{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 		X509 *peerCert = x509StoreContext->cert;
+#else
+		X509 *peerCert = X509_STORE_CTX_get0_cert(x509StoreContext);
+#endif
 
 		foreach(const QString &host, checkHosts)
 		{


### PR DESCRIPTION
With OpenSSL 1.1, the structure of X509_STORE_CTX isn't defined
publicly. Therefore, one can not directly access its members, but
must use accessor functions.

To keep compatibility with OpenSSL 1.0, encapsulate the change
with an #ifdef.

For reference, the error message when trying to build with OpenSSL 1.1, but without this fix, is:
```
g++ -c -m64 -pipe -g -O2 -fdebug-prefix-map=/tmp/buildd/zurl-1.7.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -O2 -fPIC -Wall -W -D_REENTRANT -DHAVE_OPENSSL -DJDNS_STATIC -DNO_IRISNET -DUSE_CURL -DQT_NO_DEBUG -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -I../jdns/include/jdns -I../qzmq/src -I../common -I../../src -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtNetwork -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -I_moc -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -o _obj/httprequest_curl.o ../httprequest_curl.cpp
../httprequest_curl.cpp: In member function 'int CurlConnection::sslVerifyCallback(X509_STORE_CTX*)':
../httprequest_curl.cpp:566:36: error: invalid use of incomplete type 'X509_STORE_CTX {aka struct x509_store_ctx_st}'
   X509 *peerCert = x509StoreContext->cert;
                                    ^~
In file included from /usr/include/openssl/crypto.h:31:0,
                 from /usr/include/openssl/comp.h:16,
                 from /usr/include/openssl/ssl.h:47,
                 from ../httprequest_curl.cpp:23:
/usr/include/openssl/ossl_typ.h:127:16: note: forward declaration of 'X509_STORE_CTX {aka struct x509_store_ctx_st}'
 typedef struct x509_store_ctx_st X509_STORE_CTX;
                ^~~~~~~~~~~~~~~~~
Makefile:674: recipe for target '_obj/httprequest_curl.o' failed
make[2]: *** [_obj/httprequest_curl.o] Error 1
make[2]: Leaving directory '/tmp/buildd/zurl-1.7.0/src/libzurl'
```
