### PR TITLE
fix curl error handling with libcurl < 7.62

### DIFF
--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -1253,6 +1253,9 @@ private slots:
 						curError = HttpRequest::ErrorConnect;
 					}
 					break;
+#if LIBCURL_VERSION_NUM < 0x073e00
+				case CURLE_SSL_CACERT:
+#endif
 				case CURLE_PEER_FAILED_VERIFICATION:
 					curError = HttpRequest::ErrorTls;
 					break;


### PR DESCRIPTION
Curl 7.62 changes CURLE_SSL_CACERT to be an alias for
CURLE_PEER_FAILED_VERIFICATION, see
https://github.com/curl/curl/commit/3f3b26d6feb0667714902e836af608094235fca2

This leads to the following error message:

../httprequest_curl.cpp: In member function 'void HttpRequest::Private::conn_updated()':
../httprequest_curl.cpp:1288:5: error: duplicate case value
     case CURLE_PEER_FAILED_VERIFICATION:
     ^~~~
../httprequest_curl.cpp:1287:5: note: previously used here
     case CURLE_SSL_CACERT:
     ^~~~

Therefore, commit 49b23fff94 removed CURLE_SSL_CACERT from the switch statement.

But for curl versions < 7.62.0, this value should still be handled. So,
re-add that switch branch for curl versions < 7.62.0.