### PR TITLE
Fetch submodules via HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "src/qzmq"]
 	path = src/qzmq
-	url = git://github.com/jkarneges/qzmq.git
+	url = https://github.com/jkarneges/qzmq.git
 [submodule "src/common"]
 	path = src/common
-	url = git://github.com/fanout/common.git
+	url = https://github.com/fanout/common.git
 [submodule "src/jdns"]
 	path = src/jdns
-	url = git://github.com/psi-im/jdns.git
+	url = https://github.com/psi-im/jdns.git


### PR DESCRIPTION
Git has deprecated non-authenticated git:
```
fatal: remote error: The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```