### PR TITLE
Handle listen error in httprequesttest

### DIFF
--- a/tests/httprequesttest/httprequesttest.cpp
+++ b/tests/httprequesttest/httprequesttest.cpp
@@ -203,7 +203,9 @@ private slots:
 		//log_setOutputLevel(LOG_LEVEL_DEBUG);
 
 		server = new HttpServer(this);
-		server->listen();
+		if(!server->listen()) {
+			QFAIL("HttpServer failed to listen");
+		}
 	}
 
 	void cleanupTestCase()


### PR DESCRIPTION
An automated rebuild of the zurl debian package failed with a
segmentation fault in HttpRequestTest::requestDnsError():
https://bugs.debian.org/1005629

While failures of network related test cases can happen in those
testing environments, a segmentation fault looked suspicious.

Fortunately, it turned out to be a bug in the test case, not in
production code: If listen() fails because no port can be assigned,
server will be set to 0, and `server->localPort()` will cause a
segmentation fault.

If the HttpServer can't initialize, there is no way to continue the
tests, but instead of a random crash. report a meaningful error.