### PR TITLE
timer_callback must return CURLM_OK on success

### DIFF
--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -713,10 +713,10 @@ public:
 		return self->socketFunction(easy, s, action, socketp);
 	}
 
-	static void timerFunction_cb(CURLM *multi, long timeout_ms, void *userp)
+	static int timerFunction_cb(CURLM *multi, long timeout_ms, void *userp)
 	{
 		CurlConnectionManager *self = (CurlConnectionManager *)userp;
-		self->timerFunction(multi, timeout_ms);
+		return self->timerFunction(multi, timeout_ms);
 	}
 
 	int socketFunction(CURL *easy, curl_socket_t s, int action, void *socketp)
@@ -772,7 +772,7 @@ public:
 		return 0;
 	}
 
-	void timerFunction(CURLM *multi, long timeout_ms)
+	int timerFunction(CURLM *multi, long timeout_ms)
 	{
 		Q_UNUSED(multi);
 
@@ -786,6 +786,7 @@ public:
 			log_debug("timerFunction: cancel timer");
 			timer->stop();
 		}
+		return 0;
 	}
 
 	void doSocketAction(bool all, int sockfd, int ev_bitmask)


### PR DESCRIPTION
As documented in https://curl.se/libcurl/c/CURLMOPT_TIMERFUNCTION.html, the callback registered with CURLMOPT_TIMERFUNCTION returns an int.

If timerFunction_cb is defined as returning void, the actual return value seen by the caller is undefined. On most architectures this seems to work by accident. But on arm64, the test cases fail, which was reported in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1103005